### PR TITLE
dependent: :destroy, to delete dependencies of trip

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -5,7 +5,7 @@ class Trip < ApplicationRecord
 
   SPORTS = ["Surfing", "Skateboarding", "Skiing/Snowboarding", "Mountain Bike", "Hiking", "Paragliding"]
 
-  has_one :album
+  has_one :album, dependent: :destroy
   # validates :album, presence: true
   # has_many :photos, through: :albums
 


### PR DESCRIPTION
Validations added on Trip model
Now, when you delete a Trip you also deletes it's album. (Otherwise, you could never delete your album anymore)

updated:
has_one :album, dependent: :destroy

original:
has_one :album